### PR TITLE
Move CUB to 1.7.3

### DIFF
--- a/condarecipe/bld.bat
+++ b/condarecipe/bld.bat
@@ -1,6 +1,7 @@
 cd %RECIPE_DIR%\..
 call "C:\Program Files (x86)\Microsoft Visual Studio 12.0\VC\vcvarsall.bat" amd64
-python build_sorting_libs.py
+%PYTHON% build_sorting_libs.py
+if errorlevel 1 exit 1
 
 mkdir %PREFIX%\DLLs
 copy %RECIPE_DIR%\..\lib\*.dll %PREFIX%\DLLs

--- a/condarecipe/build.sh
+++ b/condarecipe/build.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 function build() {
   cd $RECIPE_DIR/..
   python build_sorting_libs.py


### PR DESCRIPTION
CUB 1.7.3 fixes a number of issues in 1.7.0, one of which was
causing access violations in cicc.exe.