### PR TITLE
Selective appending of architecture options based on CUDA version

### DIFF
--- a/build_sorting_libs.py
+++ b/build_sorting_libs.py
@@ -52,9 +52,15 @@ def gencode_flags():
     GENCODE_COMPUTEXX = "-gencode arch=compute_{CC},code=compute_{CC}"
     GENCODE_COMPUTE53 = GENCODE_COMPUTEXX.format(CC=53)
 
+    # Get CUDA version
+    _cuda_version = cuda_version()
+
     # Concatenate flags
     SM = []
-    SM.append(GENCODE_SM20)
+    # Not all architectures are supported by all CUDA versions
+    if _cuda_version:
+        if _cuda_version['major'] <= 8:
+            SM.append(GENCODE_SM20)
     SM.append(GENCODE_SM30)
     SM.append(GENCODE_SM35)
     SM.append(GENCODE_SM37)

--- a/build_sorting_libs.py
+++ b/build_sorting_libs.py
@@ -65,8 +65,7 @@ def gencode_flags():
 
 
 def build_cuda(srcdir, out, ins, includes):
-    # Allow specification of nvcc location in NVCC env var
-    nvcc = os.environ.get('NVCC', 'nvcc')
+    nvcc = locate_nvcc()
 
     # Build for 32- or 64-bit
     optflags = '-m%s --compiler-options "-fPIC"'
@@ -84,6 +83,15 @@ def build_cuda(srcdir, out, ins, includes):
                           inp=inputs, opt=opt)
     cmd = ' '.join([nvcc, args])
     run_shell(cmd)
+
+
+def locate_nvcc():
+    """
+    Locate nvcc command on the platform, allowing specification
+    of nvcc location in NVCC env var.
+
+    """
+    return os.environ.get('NVCC', 'nvcc')
 
 
 def build_radixsort():

--- a/build_sorting_libs.py
+++ b/build_sorting_libs.py
@@ -1,6 +1,7 @@
 # A script to build external dependencies
 
 import os
+import sys
 import subprocess
 import platform
 
@@ -92,6 +93,26 @@ def locate_nvcc():
 
     """
     return os.environ.get('NVCC', 'nvcc')
+
+
+def cuda_version():
+    r"""
+    Get installed CUDA version by calling ``nvcc --version`` and parsing its
+    output. This method never raises an exception.
+
+    :returns: a dictionary describing the version, if the command is run and
+    output parsed successfully, ``None`` otherwise. For instance:
+    >>> {'major': 9, 'minor': 2, 'patch': 148}
+    """
+    nvcc = locate_nvcc()
+    full_output = subprocess.check_output([nvcc, '--version'], stderr=sys.stdout)
+    try:
+        version_numbers_str = full_output.strip().split('V')[-1].split('.')
+        return {'major': int(version_numbers_str[0]),
+                'minor': int(version_numbers_str[1]),
+                'patch': int(version_numbers_str[2])}
+    except:
+        return None
 
 
 def build_radixsort():

--- a/build_sorting_libs.py
+++ b/build_sorting_libs.py
@@ -110,9 +110,10 @@ def cuda_version():
     output parsed successfully, ``None`` otherwise. For instance:
     >>> {'major': 9, 'minor': 2, 'patch': 148}
     """
-    nvcc = locate_nvcc()
-    full_output = subprocess.check_output([nvcc, '--version'], stderr=sys.stdout)
     try:
+        nvcc = locate_nvcc()
+        full_output = subprocess.check_output([nvcc, '--version'],
+                                              stderr=sys.stdout)
         version_numbers_str = full_output.strip().split('V')[-1].split('.')
         return {'major': int(version_numbers_str[0]),
                 'minor': int(version_numbers_str[1]),


### PR DESCRIPTION
Closes #8 

As suggested in https://github.com/numba/pyculib_sorting/issues/8#issuecomment-414956112, these changes ensure that CC 2.0 architecture options are appended only for CUDA versions prior to 9.0. 

I can confirm that with these changes I was able to build the libraries on a platform with the following specs:

* Ubuntu 16.04.5 LTS
* GeForce GTX TITAN X
* CUDA 9.2.148